### PR TITLE
Fix the Default implementation for Registry

### DIFF
--- a/.github/workflows/rust_build_and_test.yml
+++ b/.github/workflows/rust_build_and_test.yml
@@ -10,31 +10,33 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build-linux:
-    runs-on: ubuntu-latest
+  build-and-test:
+    name: ${{ matrix.make.name }} (${{ matrix.target.name }})
+    runs-on: ${{ matrix.target.gh_env }}
+    strategy:
+      fail-fast: false
+      matrix:
+        rust: [nightly]
+        target:
+          - name: x86_64-unknown-linux-gnu
+            gh_env: ubuntu-latest
+          - name: aarch64-apple-darwin
+            gh_env: macos-11
+          - name: x86_64-apple-darwin
+            gh_env: macos-11
 
     steps:
       - uses: actions/checkout@v2
-      - name: Install latest nightly
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-      - name: Build
-        run: cargo build --verbose
-      - name: Run tests
-        run: cargo test --verbose
+      # When rustup is updated, it tries to replace its binary, which on Windows is somehow locked.
+      # This can result in the CI failure, see: https://github.com/rust-lang/rustup/issues/3029
+      - name: Setup rust
+        run: |
+          rustup set auto-self-update disable
+          rustup toolchain install ${{ matrix.rust}}-${{ matrix.target.name }} --profile minimal
 
-  build-mac:
-    runs-on: macos-latest
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install latest nightly
-        uses: actions-rs/toolchain@v1
+      - uses: Swatinem/rust-cache@v2
         with:
-          toolchain: nightly
-          override: true
+          shared-key: ${{ matrix.target.name }}--branch--${{ github.ref }}
       - name: Build
         run: cargo build --verbose
       - name: Run tests

--- a/src/fake/mod.rs
+++ b/src/fake/mod.rs
@@ -48,7 +48,6 @@ mod tempdir;
 pub struct FakeFileSystem {
     registry: Arc<Mutex<Registry>>,
 }
-
 impl FakeFileSystem {
     pub fn new() -> Self {
         let registry = Registry::new();

--- a/src/fake/registry.rs
+++ b/src/fake/registry.rs
@@ -25,10 +25,16 @@ use std::path::{Component, Path, PathBuf};
 
 use super::node::{Dir, File, Node, Symlink};
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct Registry {
     cwd: PathBuf,
     files: HashMap<PathBuf, Node>,
+}
+
+impl Default for Registry {
+    fn default() -> Self {
+        Registry::new()
+    }
 }
 
 impl Registry {


### PR DESCRIPTION
Summary:

Since this is used in the FakeFileSystem, it also means that a default FakeFileSystem doesn't work at all.

Test Plan:

Honestly just unit tests